### PR TITLE
Trim names on Firefox

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -20,7 +20,7 @@ export const parseText = (rawText: string): Result[] => {
       const values = lines[i].match(pointsRegex);
       const name = lines[i].match(/(.+) \(/);
       currResult = {
-        name: name != null ? name[1] : '',
+        name: name != null ? name[1].trim() : '',
         value: values != null ? Number(values[1]) - Number(values[2]) : 0,
         message: '',
       };


### PR DESCRIPTION
Currently on Firefox, the regex [here](https://github.com/ljones315/smolt/blob/57e94c4e87a984ace9d2ad45c54537307ba3e798/src/parse.ts#L21)

`const name = lines[i].match(/(.+) \(/);`

does not trim spaces when copying and pasting the text in Firefox. This PR trims the name, so there isn't extra spacing between the points and comment.

Example:

`[-1]     Deduction` becomes `[-1] Deduction`